### PR TITLE
Make log target configurable

### DIFF
--- a/examples/pl_target.rs
+++ b/examples/pl_target.rs
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Inria
+ * SPDX-FileCopyrightText: 2023 Sebastiano Vigna
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+use dsi_progress_logger::*;
+use log::info;
+use std::thread;
+use stderrlog;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    stderrlog::new()
+        .verbosity(2)
+        .show_module_names(true)
+        .timestamp(stderrlog::Timestamp::Second)
+        .init()?;
+
+    let mut pl = ProgressLogger::default();
+    pl.item_name("pumpkin").log_target("slow smashing");
+
+    pl.start("Smashing pumpkins (slowly)...");
+    for _ in 0..30 {
+        thread::sleep(std::time::Duration::from_millis(1000));
+        pl.update();
+    }
+    pl.done();
+
+    info!("");
+
+    let mut pl = ProgressLogger::default();
+    pl.display_memory(true)
+        .item_name("pumpkin")
+        .local_speed(true)
+        .log_target("fast smashing");
+
+    pl.start("Smashing pumpkins...");
+    for _ in 0..300 {
+        thread::sleep(std::time::Duration::from_millis(100));
+        pl.update();
+    }
+    pl.done();
+
+    Ok(())
+}


### PR DESCRIPTION
You may have noticed `dsi_progress_logger` appearing in webgraph's executable's output:

```
[2024-03-24T15:49:45Z INFO  dsi_progress_logger] Elapsed: 2m 7s [176,569,127 nodes, 1386986.24 nodes/s, 720.99 ns/node]
[2024-03-24T15:49:45Z INFO  dsi_progress_logger] 578 updates, 20h 20m 32s, 28.41 updates/h, 2.11 m/update
[2024-03-24T15:49:45Z INFO  webgraph::algo::llp] Gain: 0.0015963978392423178
[2024-03-24T15:49:45Z INFO  webgraph::algo::llp] Modified: 43606748
[2024-03-24T15:49:45Z INFO  dsi_progress_logger] Starting update 578...
[2024-03-24T15:49:55Z INFO  dsi_progress_logger] 1,639,017 nodes, 10s, 160952.13 nodes/s, 6.21 μs/node [160952.13 nodes/s, 6.21 μs/node]
[2024-03-24T15:50:05Z INFO  dsi_progress_logger] 9,297,387 nodes, 20s, 459917.33 nodes/s, 2.17 μs/node [763386.66 nodes/s, 1.31 μs/node]
```

This allows configuring it to a different value