### PR TITLE
Make 'utils' public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use std::time::{Duration, Instant};
 use sysinfo::{Pid, ProcessExt, ProcessRefreshKind, RefreshKind, System, SystemExt};
 
 mod utils;
-use utils::*;
+pub use utils::*;
 
 /**
 


### PR DESCRIPTION
The TimeUnit struct and functions defined in this module are marked 'pub', but not actually accessible.

This prevents other crates from calling ProgressLog::time_unit or implementing ProgressLog.