### PR TITLE
Add BufferedProgressLogger for easier multi-threaded progress logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,6 @@ pluralizer = "0.4.0"
 sysinfo = "0.29.10"
 
 [dev-dependencies]
+num_cpus = "1.16.0"
+rayon = "1.10.0"
 stderrlog = "0.5.4"

--- a/examples/pl_multithread.rs
+++ b/examples/pl_multithread.rs
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Inria
+ * SPDX-FileCopyrightText: 2023 Sebastiano Vigna
+ * SPDX-FileCopyrightText: 2024 Fondation Inria
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+use std::sync::{Arc, Mutex};
+
+use dsi_progress_logger::*;
+use rayon::prelude::*;
+use stderrlog;
+
+const ITER_PER_THREAD: u64 = 1000000000;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    stderrlog::new()
+        .verbosity(2)
+        .timestamp(stderrlog::Timestamp::Second)
+        .init()?;
+
+    // With raw threads
+    let mut pl = ProgressLogger::default();
+    pl.item_name("pumpkin");
+    pl.start("Smashing pumpkins (with raw threads)...");
+
+    std::thread::scope(|s| {
+        let buffered_pl = BufferedProgressLogger::new(Arc::new(Mutex::new(&mut pl)));
+        for i in 0..num_cpus::get() {
+            let mut buffered_pl = buffered_pl.clone();
+            s.spawn(move || {
+                let i = i as u64;
+                for _ in (i * ITER_PER_THREAD)..(i + 1) * ITER_PER_THREAD {
+                    buffered_pl.light_update();
+                }
+            });
+        }
+    });
+    pl.done();
+
+    // With rayon
+    let mut pl = progress_logger!(
+        item_name = "pumpkin",
+        display_memory = true,
+        local_speed = true
+    );
+    pl.start("Smashing pumpkins (with rayon)");
+
+    (0..(num_cpus::get() as u64) * ITER_PER_THREAD)
+        .into_par_iter()
+        .for_each_with(
+            BufferedProgressLogger::new(Arc::new(Mutex::new(&mut pl))),
+            |buffered_pl, _| buffered_pl.light_update(),
+        );
+    pl.done();
+
+    Ok(())
+}

--- a/src/buffered.rs
+++ b/src/buffered.rs
@@ -63,9 +63,11 @@ impl<T: DerefMut<Target: ProgressLog>> BufferedProgressLogger<T> {
 }
 
 impl<T: DerefMut<Target: ProgressLog>> ProgressLog for BufferedProgressLogger<T> {
+    #[inline]
     fn update(&mut self) {
         self.update_with_count(1)
     }
+    #[inline]
     fn update_with_count(&mut self, count: usize) {
         match usize::from(self.count).checked_add(count) {
             None => {
@@ -89,9 +91,11 @@ impl<T: DerefMut<Target: ProgressLog>> ProgressLog for BufferedProgressLogger<T>
             }
         }
     }
+    #[inline]
     fn light_update(&mut self) {
         self.update_with_count(1)
     }
+    #[inline]
     fn update_and_display(&mut self) {
         let mut inner = self.inner.lock().unwrap();
         inner.update_with_count(self.count.into());

--- a/src/buffered.rs
+++ b/src/buffered.rs
@@ -1,0 +1,124 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Fondation Inria
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+use std::ops::DerefMut;
+use std::sync::{Arc, Mutex};
+
+use super::ProgressLog;
+
+/// How many updates [`BufferedProgressLogger`] accumulates by default before sending
+/// them to the underlying [`ProgressLog`].
+pub const DEFAULT_THRESHOLD: u16 = 32768;
+
+#[derive(Debug)]
+/// A wrapper for `Arc<Mutex<ProgressLogConfig>>` that buffers writes to the underlying
+/// [`ProgressLogConfig`] to avoid taking the lock too often.
+///
+/// This is useful when writing to a common [`ProgressLogConfig`] from multiple threads.
+/// # Examples
+///
+///
+/// ```rust
+/// use dsi_progress_logger::prelude::*;
+///
+/// let mut pl = progress_logger!(item_name="pumpkin", display_memory=true);
+/// ```
+pub struct BufferedProgressLogger<T: DerefMut<Target: ProgressLog>> {
+    inner: Arc<Mutex<T>>,
+    count: u16,
+    threshold: u16,
+}
+
+impl<T: DerefMut<Target: ProgressLog>> BufferedProgressLogger<T> {
+    pub fn new(pl: Arc<Mutex<T>>) -> Self {
+        Self::with_threshold(pl, DEFAULT_THRESHOLD)
+    }
+
+    /// Creates a new `BufferedProgressLogger` that accumulates updates up to `threshold`,
+    /// before flushing to the underlying [`ProgressLog`].
+    pub fn with_threshold(pl: Arc<Mutex<T>>, threshold: u16) -> Self {
+        Self {
+            inner: pl,
+            count: 0,
+            threshold,
+        }
+    }
+
+    pub fn inner(&self) -> &Arc<Mutex<T>> {
+        &self.inner
+    }
+
+    pub fn flush(&mut self) {
+        if self.count > 0 {
+            self.inner
+                .lock()
+                .unwrap()
+                .update_with_count(self.count.into());
+            self.count = 0;
+        }
+    }
+}
+
+impl<T: DerefMut<Target: ProgressLog>> ProgressLog for BufferedProgressLogger<T> {
+    fn update(&mut self) {
+        self.update_with_count(1)
+    }
+    fn update_with_count(&mut self, count: usize) {
+        match usize::from(self.count).checked_add(count) {
+            None => {
+                // Sum overflows, update in two steps
+                let mut inner = self.inner.lock().unwrap();
+                inner.update_with_count(self.count.into());
+                inner.update_with_count(count);
+                self.count = 0;
+            }
+            Some(total_count) => {
+                if total_count >= usize::from(self.threshold) {
+                    // Threshold reached, time to flush to the inner ProgressLogConfig
+                    let mut inner = self.inner.lock().unwrap();
+                    inner.update_with_count(total_count);
+                    self.count = 0;
+                } else {
+                    // total_count is lower than self.threshold, which is a u16;
+                    // so total_count fits in u16.
+                    self.count = total_count as u16;
+                }
+            }
+        }
+    }
+    fn light_update(&mut self) {
+        self.update_with_count(1)
+    }
+    fn update_and_display(&mut self) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.update_with_count(self.count.into());
+        self.count = 0;
+        inner.update_and_display()
+    }
+}
+
+/// Flush count buffer to the inner [`ProgressLog`]
+impl<T: DerefMut<Target: ProgressLog>> Drop for BufferedProgressLogger<T> {
+    fn drop(&mut self) {
+        if self.count > 0 {
+            self.inner
+                .lock()
+                .unwrap()
+                .update_with_count(self.count.into());
+            self.count = 0;
+        }
+    }
+}
+
+impl<T: DerefMut<Target: ProgressLog>> Clone for BufferedProgressLogger<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            count: 0, // Not copied or it would cause double-counting!
+            threshold: self.threshold,
+        }
+    }
+}


### PR DESCRIPTION
This moves the `update` methods to a new trait, because it does not really make sense for this new struct to provide access to the other methods.

I've been using it in swh-graph, to replace my many instances of:

```
let pl = Arc::new(Mutex::new(&mut pl));
iterator
    .enumerate()
    .for_each(|(i, ...)| {
        // ...
        if i % 32768 == 0 {
            pl.lock().unwrap().update_with_count(32768)
        }
    })
```

with:

```
iterator
    .for_each_with(
        || BufferedProgressLogger::new(Arc::new(Mutex::new(&mut pl))),
        |buffered_pl, ...| {
            // ...
            buffered_pl.light_update();
        }
    )
```

which is simpler and does not overcount.