### PR TITLE
Don't request sysinfo's multithread feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ authors = [
 log = "0.4.17"
 num-format = "0.4.4"
 pluralizer = "0.5.0"
-sysinfo = "0.33.1"
+sysinfo = { version = "0.33.1", default-features = false, features = ["system"] }
 
 [dev-dependencies]
 env_logger = "0.11.6"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ the same underlying [`ProgressLog`], that can be passed to other threads. As a
 result, a [`ConcurrentProgressLog`] can be used with methods like
 [`rayon::ParallelIterator::for_each_with`](https://docs.rs/rayon/latest/rayon/iter/trait.ParallelIterator.html#method.for_each_with),
 [`rayon::ParallelIterator::map_with`](https://docs.rs/rayon/latest/rayon/iter/trait.ParallelIterator.html#method.map_with),
-and so on (but in this case do not use the [`display_memory`] method, as [this
+and so on (but in this case do not use the [`display_memory`] method if an
+other crate in your compilation unit depends on on [`sysinfo`](https://crates.io/crates/sysinfo)'s
+(default) `multithread` feature, as [this
 can lead to a deadlock](https://github.com/rayon-rs/rayon/issues/592)).
 Convenience constructors and macros make concurrent progress logging as easy as
 single-threaded logging.


### PR DESCRIPTION
In order to mitigate [deadlocks when dsi-progress-logger is used from rayon workers](https://github.com/vigna/dsi-progress-logger-rs/issues/13).

It also avoids dependency on serde and rayon in executables that don't need them.
